### PR TITLE
replace 'Epic Link' with 'parentEpic' in JQL queries for issue retrieval

### DIFF
--- a/jira_agile_toolbox/__init__.py
+++ b/jira_agile_toolbox/__init__.py
@@ -104,7 +104,7 @@ class JiraAgileToolBox:
         """
         fields_to_get = self._input_validation_fields(fields)
         epic_key = epic.key if isinstance(epic, jira.Issue) else epic
-        jql_query_to_find_the_issues = f"'Epic Link' = {epic_key} AND {jql_query}" if jql_query else f"'Epic Link' = {epic_key}"
+        jql_query_to_find_the_issues = f"'parentEpic' = {epic_key} AND {jql_query}" if jql_query else f"'parentEpic' = {epic_key}"
         if fields_to_get:
             return self._jira_client.search_issues(jql_query_to_find_the_issues, fields=fields_to_get, maxResults=0)
         return self._jira_client.search_issues(jql_query_to_find_the_issues, maxResults=0)

--- a/tests/test_epic_interactions.py
+++ b/tests/test_epic_interactions.py
@@ -54,7 +54,7 @@ class TestEpicStoryPointRetrieval(TestCase):
         jat.get_storypoints_from_epic(epic)
 
         # Then
-        self.jira_client.search_issues.assert_called_with(f"'Epic Link' = {epic}", fields=["customfield_10282", "status"], maxResults=0)
+        self.jira_client.search_issues.assert_called_with(f"'parentEpic' = {epic}", fields=["customfield_10282", "status"], maxResults=0)
 
     def test_get_story_points_from_epic_looks_in_jira_for_all_children_of_the_epic_passes_on_a_jql_query(self):
         # Given
@@ -74,7 +74,7 @@ class TestEpicStoryPointRetrieval(TestCase):
 
         # Then
         self.jira_client.search_issues.assert_called_with(
-            f"'Epic Link' = {epic} AND {jql_query}", fields=["customfield_10282", "status"], maxResults=0
+            f"'parentEpic' = {epic} AND {jql_query}", fields=["customfield_10282", "status"], maxResults=0
         )
 
     def test_get_story_points_from_epic_calculates_the_total_story_pointS_for_3_issues(self):
@@ -205,7 +205,7 @@ class TestEpicStoryPointRetrieval(TestCase):
         self.jira_client.fields.assert_called_once()
 
         self.jira_client.search_issues.assert_called_with(
-            "'Epic Link' = " + "PROJ001-001", fields=["customfield_10333", "status"], maxResults=0
+            "'parentEpic' = " + "PROJ001-001", fields=["customfield_10333", "status"], maxResults=0
         )
 
         self.assertEqual({"total": 100, "Reported": 100}, result)
@@ -228,7 +228,7 @@ class TestEpicStoryPointRetrieval(TestCase):
         self.jira_client.fields.assert_called_once()
 
         self.jira_client.search_issues.assert_called_with(
-            "'Epic Link' = " + "PROJ001-001", fields=["customfield_10282", "status"], maxResults=0
+            "'parentEpic' = " + "PROJ001-001", fields=["customfield_10282", "status"], maxResults=0
         )
 
         self.assertEqual({"total": 100, "Reported": 100}, result)
@@ -254,7 +254,7 @@ class TestGetIssuesInEpic(TestCase):
 
         # Then
         self.assertEqual(self.jira_client.search_issues.return_value, result)
-        self.jira_client.search_issues.assert_called_with("'Epic Link' = PROJ001-001", maxResults=0)
+        self.jira_client.search_issues.assert_called_with("'parentEpic' = PROJ001-001", maxResults=0)
 
     def test_get_issues_from_epic_can_filter_on_the_fields_to_retrieve_to_reduce_data_retrieval(self):
         # Given
@@ -271,7 +271,7 @@ class TestGetIssuesInEpic(TestCase):
         jat.get_all_issues_in_epic("PROJ001-001", fields=["a_specific_field"])
 
         # Then
-        self.jira_client.search_issues.assert_called_with("'Epic Link' = PROJ001-001", fields=["a_specific_field"], maxResults=0)
+        self.jira_client.search_issues.assert_called_with("'parentEpic' = PROJ001-001", fields=["a_specific_field"], maxResults=0)
 
     def test_get_issues_from_epic_takes_a_string_field_or_a_list_of_fields(self):
         # Given
@@ -288,7 +288,7 @@ class TestGetIssuesInEpic(TestCase):
         jat.get_all_issues_in_epic("PROJ001-001", fields="a_specific_field")
 
         # Then
-        self.jira_client.search_issues.assert_called_with("'Epic Link' = PROJ001-001", fields=["a_specific_field"], maxResults=0)
+        self.jira_client.search_issues.assert_called_with("'parentEpic' = PROJ001-001", fields=["a_specific_field"], maxResults=0)
 
     def test_get_issues_from_epic_allows_to_filter_an_extra_jql_query(self):
         # Given
@@ -306,7 +306,7 @@ class TestGetIssuesInEpic(TestCase):
 
         # Then
         self.jira_client.search_issues.assert_called_with(
-            "'Epic Link' = PROJ001-001 AND project in (PROJ001,PROJ002)", fields=["a_specific_field"], maxResults=0
+            "'parentEpic' = PROJ001-001 AND project in (PROJ001,PROJ002)", fields=["a_specific_field"], maxResults=0
         )
 
 
@@ -346,7 +346,7 @@ class TestSetVersionNumberForAllItemsInEpic(TestCase):
         jat.copy_fix_version_from_epic_to_all_items_in_epic(epic)
 
         # Then
-        self.jira_client.search_issues.assert_called_with(f"'Epic Link' = {epic.key}", fields=["fixVersions"], maxResults=0)
+        self.jira_client.search_issues.assert_called_with(f"'parentEpic' = {epic.key}", fields=["fixVersions"], maxResults=0)
 
     def test_copy_fix_version_from_epic_to_all_items_in_epic_searches_for_the_epic_and_passes_on_extra_jql_query(self):
         # Given
@@ -364,7 +364,9 @@ class TestSetVersionNumberForAllItemsInEpic(TestCase):
         jat.copy_fix_version_from_epic_to_all_items_in_epic(epic, jql_query=jql_query)
 
         # Then
-        self.jira_client.search_issues.assert_called_with(f"'Epic Link' = {epic.key} AND {jql_query}", fields=["fixVersions"], maxResults=0)
+        self.jira_client.search_issues.assert_called_with(
+            f"'parentEpic' = {epic.key} AND {jql_query}", fields=["fixVersions"], maxResults=0
+        )
 
     def test_copy_fix_version_from_epic_to_all_items_in_epic_for_multiple_versions(self):
         # Given

--- a/tests/test_label_interactions.py
+++ b/tests/test_label_interactions.py
@@ -68,7 +68,7 @@ class TestLabelSettingForSubItemsOfAnEpic(unittest.TestCase):
         jat.add_labels_to_all_sub_items_of_epic("PROJ001-001", ["label_to_set"])
 
         # Then
-        self.jira_client.search_issues.assert_called_with("'Epic Link' = PROJ001-001", fields=["labels"], maxResults=0)
+        self.jira_client.search_issues.assert_called_with("'parentEpic' = PROJ001-001", fields=["labels"], maxResults=0)
 
     def test_setting_a_label_for_all_sub_items_passes_on_the_jql_query(self):
         # Given
@@ -85,7 +85,7 @@ class TestLabelSettingForSubItemsOfAnEpic(unittest.TestCase):
         jat.add_labels_to_all_sub_items_of_epic(epic, ["label_to_set"], jql_query=jql_query)
 
         # Then
-        self.jira_client.search_issues.assert_called_with(f"'Epic Link' = {epic} AND {jql_query}", fields=["labels"], maxResults=0)
+        self.jira_client.search_issues.assert_called_with(f"'parentEpic' = {epic} AND {jql_query}", fields=["labels"], maxResults=0)
 
     def test_setting_a_label_for_all_sub_items_will_remove_already_present_labels(self):
         # Given


### PR DESCRIPTION
## Summary by Sourcery

Replace JQL field 'Epic Link' with 'parentEpic' in issue retrieval methods

Enhancements:
- Update query construction in get_all_issues_in_epic to use 'parentEpic' instead of 'Epic Link'

Tests:
- Adjust tests to assert that JQL calls use 'parentEpic' across story point, fix version, and label operations